### PR TITLE
Fix - 334

### DIFF
--- a/includes/extras.php
+++ b/includes/extras.php
@@ -65,11 +65,13 @@ if ( ! function_exists( 'lsx_body_class' ) ) :
 			$classes[] = $post->post_name;
 		}
 
-		if ( class_exists( 'LSX_Banners' ) || empty( apply_filters( 'lsx_banner_plugin_disable', false ) ) ) {
+		if ( class_exists( 'LSX_Banners' ) && empty( apply_filters( 'lsx_banner_plugin_disable', false ) ) ) {
 			$post_types = array( 'page', 'post' );
 			$post_types = apply_filters( 'lsx_allowed_post_type_banners', $post_types );
 
-			if ( is_singular( $post_types ) && has_post_thumbnail() ) {
+			$img_group = get_post_meta( $post->ID, 'image_group', true );
+
+			if ( is_singular( $post_types ) && ! empty( $img_group ) && is_array( $img_group ) && ! empty( $img_group['banner_image'] ) ) {
 				$classes[] = 'page-has-banner';
 			}
 		}


### PR DESCRIPTION
### Description of the Change

This fix is to make sure the `page-has-banner` body class is properly set, and to make sure that the 'Disable Title' meta box is working correctly on posts that are edited with the block editor.

### Benefits

This will allow older posts that are edited with the block editor to have the banner easily enabled or disabled.

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx/issues/334

