### PR TITLE
* Fixed - Fixing the default banner for the events archives

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 * Add - Adding compatibility for WordPress 5.4.
 * Added - `lsx_header_wrap_after` to allow actions above the .wrap.container
 * Added - `lsx_get_template_part()` allowing 3rd part plugin to overwrite the index.php content template.
+* Fixed - Fixing the default banner for the events archives
 
 ### 2.6.1
 * Fix - Removing `lsx_defer_parsing_of_js` and `preload_css` because they have conflicts with cache plugins.

--- a/includes/the-events-calendar/the-events-calendar.php
+++ b/includes/the-events-calendar/the-events-calendar.php
@@ -123,8 +123,13 @@ if ( ! function_exists( 'lsx_tec_global_header_title' ) ) :
 		if ( is_singular( 'tribe_events' ) ) {
 			add_filter( 'the_title', 'lsx_text_disable_body_title', 200, 1 );
 		}
+
+		if ( class_exists( 'LSX_Banners' ) ) {
+			$title = '<h1 class="page-title">' . $title . '</h1>';
+		}
 		return $title;
 	}
+	add_filter( 'lsx_banner_title', 'lsx_tec_global_header_title', 200, 1 );
 	add_filter( 'lsx_global_header_title', 'lsx_tec_global_header_title', 200, 1 );
 
 endif;


### PR DESCRIPTION
### Description of the Change
I have added the Events title function to the `lsx_banner_title` as well.  

### Benefits
When the page loads, 

### Possible Drawbacks
The new Tribe events is all ajax, so our banner title and search filters do not refresh when clicked.

### Verification Process
![Screenshot 2020-03-17 at 22 04 15](https://user-images.githubusercontent.com/1805603/76925062-e8727680-68e0-11ea-9a0c-8836eed00d1a.png)

![Screenshot 2020-03-17 at 21 59 30](https://user-images.githubusercontent.com/1805603/76925066-eb6d6700-68e0-11ea-8c73-3591cab9cd0d.png)

![Screenshot 2020-03-17 at 22 04 48](https://user-images.githubusercontent.com/1805603/76925069-edcfc100-68e0-11ea-8a75-6206af6d0fb9.png)


### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues
#267 
