### PR TITLE
#267 - Fixing the custom banner title for the events archives

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,8 @@
 * Add - Adding compatibility for WordPress 5.4.
 * Added - `lsx_header_wrap_after` to allow actions above the .wrap.container
 * Added - `lsx_get_template_part()` allowing 3rd part plugin to overwrite the index.php content template.
-* Fixed - Fixing the default banner for the events archives
+* Fixed - Fixing the default banner title for the events archives
+* Fixed - Fixing the custom banner title for the events archives
 
 ### 2.6.1
 * Fix - Removing `lsx_defer_parsing_of_js` and `preload_css` because they have conflicts with cache plugins.

--- a/includes/the-events-calendar/the-events-calendar.php
+++ b/includes/the-events-calendar/the-events-calendar.php
@@ -125,6 +125,10 @@ if ( ! function_exists( 'lsx_tec_global_header_title' ) ) :
 		}
 
 		if ( class_exists( 'LSX_Banners' ) ) {
+			$options = get_option( '_lsx_settings', false );
+			if ( is_array( $options ) && isset( $options['tribe_events'] ) && isset( $options['tribe_events']['title'] ) && '' !== $options['tribe_events']['title'] ) {
+				$title = $options['tribe_events']['title'];
+			}
 			$title = '<h1 class="page-title">' . $title . '</h1>';
 		}
 		return $title;


### PR DESCRIPTION
### Description of the Change
I have fixed the output of the custom title set via the theme options.

### Verification Process
![Screenshot 2020-03-18 at 06 36 00](https://user-images.githubusercontent.com/1805603/76925668-dabdf080-68e2-11ea-8f16-fe56dbee698b.png)

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues
#267 

### Changelog Entry
Fixed - Fixing the custom banner title for the events archives
