### PR TITLE
Fixed issue #346 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # LSX Change log
 
+# [[2.7.1]] - In Development
+
+### Fixed
+- Fixed issue #346 'If LSX banners is not enabled there is a simple banner showing on each page.'.
+
 
 ## [[2.7.0]](https://github.com/lightspeeddevelopment/lsx/releases/tag/2.7.0) - 2020-03-30
 

--- a/includes/gutenberg.php
+++ b/includes/gutenberg.php
@@ -52,3 +52,15 @@ add_action('body_class', function( $classes ) {
 		$classes[] = 'using-gutenberg';
 	return $classes;
 });
+
+/**
+ * Removes the default LSX banner if there is a page that is using blocks. (Only works if LSX banners is not turned on)
+ *
+ * @return void
+ */
+function remove_lsx_page_banner_when_using_blocks() {
+	if ( function_exists( 'has_blocks' ) && ( ! class_exists( 'LSX_Banners' ) ) ) {
+		add_filter( 'lsx_page_banner_disable', '__return_true' );
+	}
+}
+add_filter( 'init', 'remove_lsx_page_banner_when_using_blocks' );


### PR DESCRIPTION
### Description of the Change

This code adds a function that will only work if LSX banners is not enabled, and if a page is using blocks, fixing the following issue: If LSX banners is not enabled there is a simple banner showing on each page.

### Benefits

There will be no double banner issue.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx/issues/346

### Changelog Entry

- Fixed issue #346 'If LSX banners is not enabled there is a simple banner showing on each page.'.
