### PR TITLE
Removed Body class 'using-gutenberg' affecting other custom post type single pages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Fixed issue #346 'If LSX banners is not enabled there is a simple banner showing on each page.'.
+- Body class `using-gutenberg` affecting other custom post type single pages was removed from any custom post type single page.
 
 
 ## [[2.7.0]](https://github.com/lightspeeddevelopment/lsx/releases/tag/2.7.0) - 2020-03-30

--- a/includes/gutenberg.php
+++ b/includes/gutenberg.php
@@ -48,7 +48,7 @@ add_filter( 'body_class', __NAMESPACE__ . '\add_gutenberg_compatible_body_class'
 
 // Add custom class for templates that are using the Gutenberg editor.
 add_action('body_class', function( $classes ) {
-	if ( function_exists( 'has_blocks' ) && has_blocks( get_the_ID() ) && ( ! is_search() ) && ( ! is_archive() ) && ( ! is_singular( 'project' ) ) )
+	if ( function_exists( 'has_blocks' ) && has_blocks( get_the_ID() ) && ( ( is_singular( 'post' ) || is_page() ) ) )
 		$classes[] = 'using-gutenberg';
 	return $classes;
 });

--- a/includes/the-events-calendar/the-events-calendar.php
+++ b/includes/the-events-calendar/the-events-calendar.php
@@ -125,7 +125,7 @@ if ( ! function_exists( 'lsx_tec_global_header_title' ) ) :
 		}
 
 		if ( class_exists( 'LSX_Banners' ) ) {
-			if ( ! is_singular() ) {
+			if ( is_archive() && is_post_type_archive( 'tribe_events' ) ) {
 				$options = get_option( '_lsx_settings', false );
 				if ( is_array( $options ) && isset( $options['tribe_events'] ) && isset( $options['tribe_events']['title'] ) && '' !== $options['tribe_events']['title'] ) {
 					$title = $options['tribe_events']['title'];


### PR DESCRIPTION
### Description of the Change

This fix is for the Body class `using-gutenberg` affecting other custom post type single pages was removed from any custom post type single page.

### Benefits

This will make sure no custom post type pages are affected by this class.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
