### PR TITLE
Fixing the integration with the "disable title"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@
 ### Added
 - Improved styling for the Tribe Events Community Events forms.
 
+### Fixed
+- Fixed the compatibility with the LSX Blocks "disable title" functionality.
+
 
 # [[2.8.0]] - 2020-05-21
 

--- a/includes/layout.php
+++ b/includes/layout.php
@@ -387,6 +387,11 @@ if ( ! function_exists( 'lsx_post_header' ) ) :
 		$default_size = 'sm';
 		$size         = apply_filters( 'lsx_bootstrap_column_size', $default_size );
 
+		$disable_title = get_post_meta( get_the_ID(), 'lsx_disable_title', true );
+		if ( 'yes' === $disable_title && is_singular( 'post' ) ) {
+			return;
+		}
+
 		if ( is_singular( 'post' ) ) :
 			$format = get_post_format();
 
@@ -446,6 +451,10 @@ endif;
 // Add entry meta to single post if active.
 if ( ! function_exists( 'lsx_add_entry_meta' ) ) :
 	function lsx_add_entry_meta() {
+		$disable_title = get_post_meta( get_the_ID(), 'lsx_disable_title', true );
+		if ( 'yes' === $disable_title && is_singular( 'post' ) ) {
+			return;
+		}
 		if ( is_single() && is_singular( 'post' ) ) {
 			?>
 			<div class="entry-meta">


### PR DESCRIPTION
### Problem
If you try and disable the page title on posts while the LSX Blocks plugin is active. Its doesnt work.

### Description of the Change
The post header function was missing the check for that, I have added it in.

### Benefits
The Disable title now works.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry
- Fixed the posts "disable title" filter.
