### PR TITLE
Fix/380 - Events banners Duplication

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -60,3 +60,4 @@ require get_template_directory() . '/includes/gutenberg.php';
 require get_template_directory() . '/includes/classes/class-lsx-schema-utils.php';
 require get_template_directory() . '/includes/classes/class-lsx-schema-graph-piece.php';
 require get_template_directory() . '/includes/classes/class-lsx-optimisation.php';
+require get_template_directory() . '/includes/classes/class-lsx-rest-helper.php';

--- a/header.php
+++ b/header.php
@@ -40,3 +40,5 @@
 
 		<div class="wrap container" role="document" tabindex="-1">
 			<div class="content role row">
+
+			<?php lsx_header_wrap_container_top(); ?>

--- a/includes/classes/class-lsx-rest-helper.php
+++ b/includes/classes/class-lsx-rest-helper.php
@@ -1,0 +1,81 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Holds functions for rest api specific actions.
+ *
+ * @author   LightSpeed
+ * @category Widgets
+ * @package  LSX
+ * @return   LSX_Rest_Helper
+ */
+class LSX_Rest_Helper {
+
+	/**
+	 * Holds class instance
+	 *
+	 * @since 1.0.0
+	 * @var      object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Holds the conditional.
+	 *
+	 * @var boolean
+	 */
+	protected $is_rest_request = false;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'tribe_events_views_v2_rest_params', array( $this, 'check_event_request' ), 10, 2 );
+	}
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @since 1.0.0
+	 * @return    object    A single instance of this class.
+	 */
+	public static function get_instance() {
+		// If the single instance hasn't been set, set it now.
+		if ( null === self::$instance ) {
+			self::$instance = new self;
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * This will set the 'is_rest_request' variable as true if it runs. Tribe has already done the checkes for us.
+	 *
+	 * @param array $params
+	 * @param array $request
+	 * @return void
+	 */
+	public function check_event_request( $params, $request ) {
+		$this->is_rest_request = true;
+	}
+
+	/**
+	 * Determines if the request is an REST API request.
+	 *
+	 * @return bool True if it's a REST API request, false otherwise.
+	 */
+	public function is_rest_api_request() {
+		if ( true === $this->is_rest_request ) {
+			return $this->is_rest_request;
+		}
+
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
+		}
+		$rest_prefix         = trailingslashit( rest_get_url_prefix() );
+		$this->is_rest_request = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) );
+		return $this->is_rest_request;
+	}
+}
+$rest_helper = LSX_Rest_Helper::get_instance();

--- a/includes/classes/class-lsx-rest-helper.php
+++ b/includes/classes/class-lsx-rest-helper.php
@@ -58,6 +58,7 @@ class LSX_Rest_Helper {
 	 */
 	public function check_event_request( $params, $request ) {
 		$this->is_rest_request = true;
+		return $params;
 	}
 
 	/**

--- a/includes/extras.php
+++ b/includes/extras.php
@@ -638,3 +638,13 @@ function lsx_breadcrumbs_blog_link( $crumbs ) {
 }
 add_filter( 'wpseo_breadcrumb_links', 'lsx_breadcrumbs_blog_link', 30, 1 );
 add_filter( 'woocommerce_get_breadcrumb', 'lsx_breadcrumbs_blog_link', 30, 1 );
+
+/**
+ * Determines if the request is an REST API request.
+ *
+ * @return bool True if it's a REST API request, false otherwise.
+ */
+function lsx_is_rest_api_request() {
+	$rest_helper = LSX_Rest_Helper::get_instance();
+	return $rest_helper->is_rest_api_request();
+}

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -97,6 +97,15 @@ function lsx_header_wrap_after() {
 }
 
 /**
+ * The 10th action which fires before the <div class="wrap container" role="document" tabindex="-1">.
+ *
+ * @return void
+ */
+function lsx_header_wrap_container_top() {
+	do_action( 'lsx_header_wrap_container_top' );
+}
+
+/**
  * Body Bottom
  *
  * @return void

--- a/includes/layout.php
+++ b/includes/layout.php
@@ -191,6 +191,10 @@ if ( ! function_exists( 'lsx_global_header' ) ) :
 			return;
 		}
 
+		if ( function_exists( 'lsx_is_rest_api_request' ) && lsx_is_rest_api_request() ) {
+			return;
+		}
+
 		if ( is_page() && ( 'page' !== $show_on_front || ! is_front_page() ) ) :
 			if ( class_exists( 'LSX_Banners' ) && empty( apply_filters( 'lsx_banner_plugin_disable', false ) && ( ! has_post_thumbnail() ) ) ) {
 				return;

--- a/includes/layout.php
+++ b/includes/layout.php
@@ -186,6 +186,11 @@ if ( ! function_exists( 'lsx_global_header' ) ) :
 			return;
 		}
 
+		// Cart and Checkout won't have banners of any kind.
+		if ( function_exists( 'tribe_is_event' ) && tribe_is_event() ) {
+			return;
+		}
+
 		if ( is_page() && ( 'page' !== $show_on_front || ! is_front_page() ) ) :
 			if ( class_exists( 'LSX_Banners' ) && empty( apply_filters( 'lsx_banner_plugin_disable', false ) && ( ! has_post_thumbnail() ) ) ) {
 				return;

--- a/includes/the-events-calendar/the-events-calendar.php
+++ b/includes/the-events-calendar/the-events-calendar.php
@@ -50,6 +50,9 @@ if ( ! function_exists( 'lsx_tec_theme_wrapper_start' ) ) :
 	 * @subpackage the-events-calendar
 	 */
 	function lsx_tec_theme_wrapper_start() {
+		if ( function_exists( 'lsx_is_rest_api_request' ) && lsx_is_rest_api_request() ) {
+			return;
+		}
 		lsx_content_wrap_before();
 		echo '<div id="primary" class="content-area ' . esc_attr( lsx_main_class() ) . '">';
 		lsx_content_before();
@@ -70,6 +73,9 @@ if ( ! function_exists( 'lsx_tec_theme_wrapper_end' ) ) :
 	 * @subpackage the-events-calendar
 	 */
 	function lsx_tec_theme_wrapper_end() {
+		if ( function_exists( 'lsx_is_rest_api_request' ) && lsx_is_rest_api_request() ) {
+			return;
+		}
 		lsx_content_bottom();
 		echo '</main>';
 		lsx_content_after();


### PR DESCRIPTION
### Requirements
The events banners are duplicating when the rest requests run.

### Description of the Change
I have added in a function which checks to see if the current request is for the REST API, if so, then it excludes the banner calls.

### Alternate Designs

![Screenshot 2020-07-15 at 13 15 10](https://user-images.githubusercontent.com/1805603/87538999-73039080-c69d-11ea-9f01-17441d18d39a.png)

![Screenshot 2020-07-15 at 13 15 14](https://user-images.githubusercontent.com/1805603/87539009-77c84480-c69d-11ea-9780-cfeac20d11d0.png)

### Verification Process
Go to the events page and change the view around.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues
#380

