### PR TITLE
Skipped the loading attribute for the custom logo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 
 - Merged two WooCommerce panels within the customizer sidebar.
 - The WooCommerce bar will be showed if active and the screen is less than 678px.
+- Skiped the loading attribute for the custom logo.
 
 ### Fixed
 

--- a/includes/extras.php
+++ b/includes/extras.php
@@ -697,7 +697,7 @@ function lsx_is_rest_api_request() {
  * @param [type] $attributes
  * @return void
  */
-function lsx_custom_logo_attributes( $attributes ){
+function lsx_custom_logo_attributes( $attributes ) {
 	$attributes['loading'] = 'eager';
 	return $attributes;
 }

--- a/includes/extras.php
+++ b/includes/extras.php
@@ -690,3 +690,15 @@ function lsx_is_rest_api_request() {
 	$rest_helper = LSX_Rest_Helper::get_instance();
 	return $rest_helper->is_rest_api_request();
 }
+
+/**
+ * Remove lazy loading on Custom logo.
+ *
+ * @param [type] $attributes
+ * @return void
+ */
+function lsx_custom_logo_attributes( $attributes ){
+	$attributes['loading'] = 'eager';
+	return $attributes;
+}
+add_filter( 'get_custom_logo_image_attributes', 'lsx_custom_logo_attributes' );


### PR DESCRIPTION
### Description of the Change

This code is for Skipping the loading attribute for the custom logo.


### Benefits

Images that load within the initial viewport, it is advisable to skip the loading attribute for that image.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx/issues/447

### Changelog Entry

- Skipped the loading attribute for the custom logo.
